### PR TITLE
[ENH-3] - Handle /boot/config.txt thru patches

### DIFF
--- a/pi-gen/stage2/04-piccolo/00-patches/03-config.diff
+++ b/pi-gen/stage2/04-piccolo/00-patches/03-config.diff
@@ -1,0 +1,22 @@
+--- stage2.orig/rootfs/boot/config.txt
++++ stage2/rootfs/boot/config.txt
+@@ -53,8 +53,17 @@
+ 
+ # Additional overlays and parameters are documented /boot/overlays/README
+ 
+-# Enable audio (loads snd_bcm2835)
+-dtparam=audio=on
++# Customize for piccolo
++## Disable audio (loads snd_bcm2835)
++dtparam=audio=off
++
++## Disable bluetooth and wifi
++dtoverlay=disable-bt
++dtoverlay=disable-wifi
++
++## Add 5-second delay on boot to allow for USB disk to spin and be ready
++bootcode_delay=5
++boot_delay=5
+ 
+ [pi4]
+ # Enable DRM VC4 V3D driver on top of the dispmanx display stack

--- a/pi-gen/stage2/04-piccolo/00-patches/series
+++ b/pi-gen/stage2/04-piccolo/00-patches/series
@@ -1,2 +1,3 @@
 01-cmdline.diff
 02-init_resize.diff
+03-config.diff

--- a/pi-gen/stage2/04-piccolo/02-run-chroot.sh
+++ b/pi-gen/stage2/04-piccolo/02-run-chroot.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-# Audio off
-sed -i -e "s/dtparam=audio=on/dtparam=audio=off/" /boot/config.txt
-
-# Disable bluetooth and wifi
-echo "dtoverlay=disable-bt" >> /boot/config.txt
-echo "dtoverlay=disable-wifi" >> /boot/config.txt
-


### PR DESCRIPTION
File pi-gen/stage2/04-piccolo/02-run-chroot.sh is no longer needed, since changes in /boot/config.txt are handled thru the patching system.

5-second delay added to the boot process to give enough time to a USB disk to spin and be ready.